### PR TITLE
fix: ZSTD crash

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 *.user
 *.userosscache
 *.sln.docstates
+.idea/
 
 # User-specific files (MonoDevelop/Xamarin Studio)
 *.userprefs

--- a/SoulsFormats/Formats/DCX.cs
+++ b/SoulsFormats/Formats/DCX.cs
@@ -191,7 +191,7 @@ namespace SoulsFormats
             br.AssertASCII("DCP\0");
             br.AssertASCII("ZSTD");
             br.AssertInt32(0x20);
-            br.AssertByte(0x15);
+            br.ReadByte(); // compression level
             br.AssertByte(0);
             br.AssertByte(0);
             br.AssertByte(0);


### PR DESCRIPTION
DLC regulation.bins don't actually load at all
FYI https://github.com/soulsmods/SoulsFormatsNEXT